### PR TITLE
add docker layer caching and `nb_conda_kernels`

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -54,3 +54,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -33,22 +33,25 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: prune
         run: docker system prune -af
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN wget http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5
     chmod 755 /opt/FastQC/fastqc && \
     rm -rf /tmp/fastqc_*
 
-RUN mamba install -c conda-forge bash_kernel
+RUN mamba install -c conda-forge bash_kernel nb_conda_kernels
 
 # create scanpy_2021 conda environment with required python packages
 COPY scanpy_2021.yaml /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,21 +20,7 @@ RUN apt-get update && \
                     man-db \
                     manpages-posix \
                     tree \
-                    -y 
-                    
-
-# build conda environment with required r packages
-COPY r-bio.yaml /tmp
-RUN mamba env create --file /tmp/r-bio.yaml
-
-# linux hack to remove paths to default R
-RUN rm -rf /opt/conda/bin/R /opt/conda/lib/R && \
-    ln -s /opt/conda/envs/r-bio/bin/R /opt/conda/bin/R
-
-# # create py-bio conda environment with required python packages
-COPY py-bio.yaml /tmp
-RUN mamba env create --file /tmp/py-bio.yaml && \
-    mamba run -n py-bio /bin/bash -c "ipython kernel install --name=py-bio"
+                    -y
 
 # STAR
 RUN wget https://github.com/alexdobin/STAR/archive/2.5.2b.zip -P /tmp && \
@@ -51,21 +37,28 @@ RUN wget http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.5
 
 RUN mamba install -c conda-forge bash_kernel nb_conda_kernels
 
+# build conda environment with required r packages
+COPY r-bio.yaml /tmp
+RUN mamba env create --file /tmp/r-bio.yaml
+
+# linux hack to remove paths to default R
+RUN rm -rf /opt/conda/bin/R /opt/conda/lib/R && \
+    ln -s /opt/conda/envs/r-bio/bin/R /opt/conda/bin/R
+
+# # create py-bio conda environment with required python packages
+COPY py-bio.yaml /tmp
+RUN mamba env create --file /tmp/py-bio.yaml
+
 # create scanpy_2021 conda environment with required python packages
 COPY scanpy_2021.yaml /tmp
-RUN mamba env create --file /tmp/scanpy_2021.yaml && \
-    mamba run -n scanpy_2021 /bin/bash -c "ipython kernel install --name=scanpy_2021"
+RUN mamba env create --file /tmp/scanpy_2021.yaml
 
 COPY spatial-tx.yml /tmp
-RUN mamba env create --file /tmp/spatial-tx.yml && \
-    mamba run -n spatial-tx /bin/bash -c "ipython kernel install --name=spatial-tx"
+RUN mamba env create --file /tmp/spatial-tx.yml
     
 COPY variant_calling.yml /tmp
-RUN mamba env create --file /tmp/variant_calling.yml && \
-    mamba run -n variant_calling /bin/bash -c "ipython kernel install --name=variant_calling"
+RUN mamba env create --file /tmp/variant_calling.yml
 
 RUN yes | unminimize || echo "done"
-
-RUN apt-get install tree -y
 
 USER $NB_USER


### PR DESCRIPTION
This PR makes two changes:
1. It adds [docker layer caching](https://docs.docker.com/build/cache/backends/gha/) to our Github action via [these changes](https://github.com/biom262/cmm262-notebook/compare/50e57aea...c649a379)
    This allows us to cache portions of our build process, so that re-builds happen only for the portions of our Dockerfile that need to be rerun, potentially saving us substantial amounts of time.
    For example, let's say that we make a commit in which the only change is to one of our conda environment files. And let's say that the environment file in question gets `COPY`-ed into the container on line 10 of the Dockerfile.
    Docker layer caching means that when the container image gets rebuilt for this commit, Docker will automatically restart the build process on line 10 instead of starting from the beginning of the Dockerfile.
2. It adds `nb_conda_kernels` in our Dockerfile and resolves #10